### PR TITLE
RCTL Apply Resource Template for non-TF resources

### DIFF
--- a/setup/createtemplates.sh
+++ b/setup/createtemplates.sh
@@ -24,6 +24,7 @@ templates=(
     #"terraform/gcp/101-vpc-instance"
     #"terraform/mks/101-caas-pnap"
     #"terraform/oci/101-caas-oke"
+    terraform/rafay/rctl-apply
     #"terraform/vcluster/101-caas"
     #"terraform/vmware/101-caas-vmware"
     #"terraform/waas/101-waas"

--- a/setup/values.yaml
+++ b/setup/values.yaml
@@ -41,6 +41,7 @@ sharingtemplates: true
 
 ## list of templates
 templates:
+- ../terraform/rafay/rctl-apply
 #  - ../terraform/naas/101-naas
 #  - ../terraform/waas/101-waas
 #  - ../terraform/vcluster/101-caas

--- a/terraform/rafay/rctl-apply/setup/templates/00-sealer.tmpl
+++ b/terraform/rafay/rctl-apply/setup/templates/00-sealer.tmpl
@@ -1,0 +1,9 @@
+{{ $glbCtx := . }}
+apiVersion: integrations.k8smgmt.io/v3
+kind: SecretSealer
+metadata:
+  name: eaas-sealer-{{ $glbCtx.projectName }}
+  project: {{ $glbCtx.projectName }}
+spec:
+  type: KubeSeal
+  version: {{ $glbCtx.version }}

--- a/terraform/rafay/rctl-apply/setup/templates/01-agent.tmpl
+++ b/terraform/rafay/rctl-apply/setup/templates/01-agent.tmpl
@@ -1,0 +1,9 @@
+{{ $glbCtx := . }}
+apiVersion: gitops.k8smgmt.io/v3
+kind: Agent
+metadata:
+  name: {{ $glbCtx.agentName }}-{{ $glbCtx.projectName }}
+  project: {{ $glbCtx.projectName }}
+spec:
+  active: true
+  type: Docker

--- a/terraform/rafay/rctl-apply/setup/templates/02-repository.tmpl
+++ b/terraform/rafay/rctl-apply/setup/templates/02-repository.tmpl
@@ -1,0 +1,14 @@
+{{ $glbCtx := . }}
+apiVersion: integrations.k8smgmt.io/v3
+kind: Repository
+metadata:
+  name: {{ $glbCtx.repoName }}-{{ $glbCtx.projectName }}
+  project: {{ $glbCtx.projectName }}
+spec:
+  agents:
+  - name: {{ $glbCtx.agentName }}-{{ $glbCtx.projectName }}
+  credentials:
+    username: {{ $glbCtx.usernName }}
+    password: {{ $glbCtx.token }}
+  endpoint: {{ $glbCtx.endPoint }}
+  type: Git

--- a/terraform/rafay/rctl-apply/setup/templates/03-pipeline.tmpl
+++ b/terraform/rafay/rctl-apply/setup/templates/03-pipeline.tmpl
@@ -1,0 +1,43 @@
+{{ $glbCtx := . }}
+apiVersion: gitops.k8smgmt.io/v3
+kind: Pipeline
+metadata:
+  name: system-sync-{{ $glbCtx.projectName }}
+  project: {{ $glbCtx.projectName }}
+spec:
+  active: true
+  stages:
+  - config:
+      destinationRepo:
+        path:
+          name: {{ $glbCtx.path }}
+        repository: {{ $glbCtx.repoName }}-{{ $glbCtx.projectName }}
+        revision: {{ $glbCtx.branch }}
+      gitToSystemSync: true
+      includedResources:
+      - name: Environment
+      - name: EnvironmentTemplate
+      - name: ConfigContext
+      - name: Agent
+      - name: Repository
+      - name: Resource
+      - name: ResourceTemplate
+      - name: Pipeline
+      sourceRepo:
+        path:
+          name: {{ $glbCtx.path }}
+        repository: {{ $glbCtx.repoName }}-{{ $glbCtx.projectName }}
+        revision: {{ $glbCtx.branch }}
+      systemToGitSync: true
+    name: sync
+    type: SystemSync
+  triggers:
+  - config:
+      repo:
+        provider: Github
+        repository: {{ $glbCtx.repoName }}-{{ $glbCtx.projectName }}
+        revision: {{ $glbCtx.branch }}
+        paths:
+        - name: {{ $glbCtx.path }}
+    name: eaas-trigger
+    type: Webhook

--- a/terraform/rafay/rctl-apply/setup/templates/04-RafayconfigContext.tmpl
+++ b/terraform/rafay/rctl-apply/setup/templates/04-RafayconfigContext.tmpl
@@ -1,0 +1,21 @@
+{{ $glbCtx := . }}
+apiVersion: eaas.envmgmt.io/v1
+Config context:
+kind: ConfigContext
+metadata:
+  name: {{ $glbCtx.RafayConfigContext }}-{{ $glbCtx.projectName }}
+  project: {{ $glbCtx.projectName }}
+spec:
+  envs:
+  - key: RCTL_API_KEY
+    sensitive: true
+    value: UPDATE_VALUE
+  - key: RCTL_API_SECRET
+    sensitive: true
+    value: UPDATE_VALUE
+  - key: RCTL_REST_ENDPOINT
+    sensitive: false
+    value: UPDATE_VALUE
+  - key: RCTL_PROJECT
+    sensitive: false
+    value: {{ $glbCtx.projectName }}

--- a/terraform/rafay/rctl-apply/setup/templates/05-rafay-resource-template.tmpl
+++ b/terraform/rafay/rctl-apply/setup/templates/05-rafay-resource-template.tmpl
@@ -1,0 +1,33 @@
+{{ $glbCtx := . }}
+apiVersion: eaas.envmgmt.io/v1
+kind: ResourceTemplate
+metadata:
+  description: Resource Template for Rafay resource in Rafay console
+  name: {{ $glbCtx.RctlApplyResourceTemplate }}-{{ $glbCtx.projectName }}
+  project: {{ $glbCtx.projectName }}
+spec:
+  agents:
+  - name: {{ $glbCtx.agentName }}-{{ $glbCtx.projectName }}
+  contexts:
+  - name: {{ $glbCtx.RafayConfigContext }}-{{ $glbCtx.projectName }}
+  provider: terraform
+  providerOptions:
+    terraform:
+      backendType: system
+      version: 1.4.6
+  repositoryOptions:
+    branch: {{ $glbCtx.branch }}
+    directoryPath: {{ $glbCtx.RctlApplytfRepoPath }}
+    name: {{ $glbCtx.repoName }}-{{ $glbCtx.projectName }}
+  variables:
+  - name: rafay_spec
+    options:
+      description: Rafay Configuration Specification
+      override:
+        type: allowed
+      required: true
+      sensitive: false
+    value: |-
+      {}
+    valueType: json
+  version: {{ $glbCtx.version }}

--- a/terraform/rafay/rctl-apply/setup/templates/06-environmentTemplate.tmpl
+++ b/terraform/rafay/rctl-apply/setup/templates/06-environmentTemplate.tmpl
@@ -1,0 +1,23 @@
+{{ $glbCtx := . }}
+apiVersion: eaas.envmgmt.io/v1
+kind: EnvironmentTemplate
+metadata:
+  annotations:
+    eaas.envmgmt.io/category: Developer Productivity
+    eaas.envmgmt.io/github: https://github.com/thirumal-rafay/demo-repo-1/tree/main/caas-mks
+  description: Allowed k8s_version changes
+  name: {{ $glbCtx.EnvironmentTemplate }}-{{ $glbCtx.projectName }}
+  project: {{ $glbCtx.projectName }}
+spec:
+  agents:
+  - name: {{ $glbCtx.agentName }}-{{ $glbCtx.projectName }}
+  hooks: {}
+  iconURL: https://docs.rafay.co/icons/rafay-logo.svg
+  readme: Self Service provisioning of any Rafay Resource
+  resources:
+  - kind: resourcetemplate
+    name: {{ $glbCtx.RctlApplyResourceTemplate }}-{{ $glbCtx.projectName }}
+    resourceOptions:
+      version: {{ $glbCtx.version }}
+    type: dynamic
+  version: {{ $glbCtx.version }}

--- a/terraform/rafay/rctl-apply/setup/values.yaml
+++ b/terraform/rafay/rctl-apply/setup/values.yaml
@@ -1,0 +1,30 @@
+##Rafay Project name
+projectName: UPDATE_EXISTING_PROJECT_NAME
+##Rafay gitops agent name
+agentName: eaas-agent
+##Rafay respository name
+repoName: eaas-repo
+##Username to access repository
+usernName: UPDATE_REPO_USERNAME
+##Token to access repository
+token: UPDATE_REPO_TOKEN
+##Repository url
+endPoint: UPDATE_REPO_ENDPOINT
+##Repository revision name
+branch: UPDATE_REPO_BRANCH
+## Repository path for Rafay to write back configuration.
+path: rafay-resources
+## Initial Version for Environment Manager resources.
+version: v1
+## https://docs.rafay.dev/env_manager/overview/
+## Environment Manager congifContext Name
+## https://docs.rafay.dev/env_manager/templates/contexts/
+RafayConfigContext: rafay-rctl-apply-cfg-ctx
+##Environment Manager resourceTemplate Name
+## https://docs.rafay.dev/env_manager/templates/resource_templates/
+RctlApplyResourceTemplate: rafay-rctl-apply-rs-tmpl
+## Environment Manager environmentTemplate Name
+## https://docs.rafay.dev/env_manager/templates/environment_templates/
+EnvironmentTemplate: rafay-rctl-apply-env-tmpl
+## Terraform code path 
+RctlApplytfRepoPath: terraform/rafay/rctl-apply/terraform

--- a/terraform/rafay/rctl-apply/terraform/apply.sh
+++ b/terraform/rafay/rctl-apply/terraform/apply.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+if [ -z "${FILE_NAME}" ]; then
+  echo "File name NOT specified"
+  exit 1
+fi
+
+if [ ! -f "${FILE_NAME}" ]; then
+  echo "File ${FILE_NAME} does not exist"
+  exit 1
+fi
+
+# shellcheck source=prerequisites.sh
+. prerequisites.sh
+download_prerequisites
+
+# Convert JSON to YAML + cleanup
+# Unfortunately RCTL does not support JSON files
+YAML_FILE_NAME="${FILE_NAME%.json}.yaml"
+./yq -P < "${FILE_NAME}" > "${YAML_FILE_NAME}"
+
+yaml_file_cleanup() {
+  # Add the pre-requisite cleanup here
+  # as we'll override the EXIT trap now
+  cleanup_prerequisites
+  # Cleanup YAML file as well
+  if [ -f "${YAML_FILE_NAME}" ]; then
+    echo "Cleaning up file ${YAML_FILE_NAME}"
+    rm "${YAML_FILE_NAME}"
+  else
+    echo "File ${YAML_FILE_NAME} does not exist"
+  fi
+}
+trap yaml_file_cleanup EXIT
+
+# Perform RCTL Apply
+./rctl --wait apply --config-file "${YAML_FILE_NAME}"

--- a/terraform/rafay/rctl-apply/terraform/delete.sh
+++ b/terraform/rafay/rctl-apply/terraform/delete.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+if [ -z "${KIND}" ]; then
+  echo "Resource type NOT specified"
+  exit 1
+fi
+
+if [ -z "${NAME}" ]; then
+  echo "Resource name NOT specified"
+  exit 1
+fi
+
+if [ -z "${PROJECT}" ]; then
+  echo "Resource project NOT specified"
+  exit 1
+fi
+
+# shellcheck source=prerequisites.sh
+. prerequisites.sh
+download_prerequisites
+
+# Run RCTL delete
+./rctl --wait delete "${KIND}" --project "${PROJECT}" "${NAME}"

--- a/terraform/rafay/rctl-apply/terraform/main.tf
+++ b/terraform/rafay/rctl-apply/terraform/main.tf
@@ -1,0 +1,65 @@
+variable "rafay_spec" {
+  description = "Rafay JSON/YAML specification"
+  type        = any
+  nullable    = false
+
+  validation {
+    condition = alltrue([
+      var.rafay_spec.kind != null,
+      var.rafay_spec.kind != "",
+      var.rafay_spec.metadata != null,
+      var.rafay_spec.metadata.name != null,
+      var.rafay_spec.metadata.name != "",
+      var.rafay_spec.metadata.project != null,
+      var.rafay_spec.metadata.project != "",
+      var.rafay_spec.spec != null,
+    ])
+    error_message = "Not a valid Rafay specification."
+  }
+}
+
+resource "random_id" "rafay_spec_file_suffix" {
+  byte_length = 4
+}
+
+resource "local_file" "rafay_spec" {
+  content         = jsonencode(var.rafay_spec)
+  filename        = "rafay-spec-${random_id.rafay_spec_file_suffix.hex}.json"
+  file_permission = "0600"
+}
+
+resource "terraform_data" "rctl_apply" {
+  triggers_replace = [
+    local_file.rafay_spec.content,
+    local_file.rafay_spec.filename
+  ]
+
+  # Run rctl apply when the YAML file changes or is created
+  provisioner "local-exec" {
+    interpreter = ["/bin/sh", "-c"]
+    command     = "./apply.sh"
+    environment = {
+      "FILE_NAME" = local_file.rafay_spec.filename
+    }
+  }
+}
+
+resource "terraform_data" "rctl_delete" {
+  input = {
+    kind                 = lower(var.rafay_spec.kind)
+    name                 = var.rafay_spec.metadata.name
+    project              = var.rafay_spec.metadata.project
+  }
+
+  # Run rctl delete when `terraform destroy` is called
+  provisioner "local-exec" {
+    when        = destroy
+    interpreter = ["/bin/sh", "-c"]
+    command     = "./delete.sh"
+    environment = {
+      "KIND"    = self.input.kind
+      "NAME"    = self.input.name
+      "PROJECT" = self.input.project
+    }
+  }
+}

--- a/terraform/rafay/rctl-apply/terraform/prerequisites.sh
+++ b/terraform/rafay/rctl-apply/terraform/prerequisites.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+set -o xtrace
+set -o errexit
+
+RCTL_URL="https://rafay-prod-cli.s3-us-west-2.amazonaws.com/publish/rctl-linux-amd64.tar.bz2"
+YQ_URL="https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64"
+
+cleanup_prerequisites() {
+    if [ -f ./rctl ]
+    then
+        echo "Cleaning up rctl"
+        rm ./rctl
+    else
+        echo "rctl does not exist"
+    fi
+    if [ -f ./yq ]
+    then
+        echo "Cleaning up yq"
+        rm ./yq
+    else
+        echo "yq does not exist"
+    fi
+}
+
+download_prerequisites() {
+
+    trap cleanup_prerequisites EXIT
+
+    # Download RCTL if it does not exist
+    if [ ! -f ./rctl ]
+    then
+        echo "Downloading rctl"
+        wget -qO- "${RCTL_URL}" | bzip2 -dc | tar xvf - ./rctl
+        chmod +x ./rctl
+        echo "Downloaded rctl"
+    else
+        echo "rctl already exists"
+    fi
+
+    # Download YQ if it does not exist
+    if [ ! -f ./yq ]
+    then
+        echo "Downloading yq"
+        wget -O ./yq "${YQ_URL}"
+        chmod +x ./yq
+        echo "Downloaded yq"
+    else
+        echo "yq already exists"
+    fi
+}


### PR DESCRIPTION
Resource template to perform RCTL Apply and delete using JSON v1/v3 API payload. Very useful when native Rafay TF provider is not yet available (for ex. MKS clusters or VMWare clusters).

Use the following value for `rafay_spec` to try this template quickly:

```json
{
    "apiVersion": "infra.k8smgmt.io/v3",
    "kind": "Namespace",
    "metadata": {
        "name": "gpu-operator",
        "project": "thirumal"
    },
    "spec": {}
}
```